### PR TITLE
docs: add sphinx-autoapi ROS doc dependency

### DIFF
--- a/panda_gazebo/docs/source/dev/doc_dev.rst
+++ b/panda_gazebo/docs/source/dev/doc_dev.rst
@@ -7,15 +7,13 @@ Release documentation
 Install requirements
 --------------------
 
-Building the :panda_gazebo:`panda_gazebo <>` documentation requires `sphinx`_,
-the ``panda_gazebo`` package and several system and python packages. To install the system dependencies, run the following command
-inside your catkin workspace:
+Building the :panda_gazebo:`panda_gazebo <>` documentation requires `sphinx`_, the ``panda_gazebo``
+package and several system and python packages. To install these requirements, you can run the
+following command inside your Catkin workspace:
 
-.. code-block:: bash
-
-    rosdep install --from-path src --ignore-src -r -y -t doc
-
-Additionally, the Python dependencies can be installed using the following `pip`_ command inside the ``./panda_gazebo`` folder:
+Alternatively, you can use the `requirements/doc_requirements.txt` file to install the Python 
+packages in your virtual environments instead of the system Python environment. This can be 
+done using the following `pip`_ command:
 
 .. code-block:: bash
 

--- a/panda_gazebo/package.xml
+++ b/panda_gazebo/package.xml
@@ -104,6 +104,7 @@
   <doc_depend>python3-sphinx</doc_depend>
   <doc_depend>python3-sphinx-rtd-theme</doc_depend>
   <doc_depend>python3-myst-parser-pip</doc_depend>
+  <doc_depend>python3-sphinx-autoapi-pip</doc_depend>
   
   <!-- The export tag contains other, unspecified, tags (Used for metapackages and
   Plugins -->


### PR DESCRIPTION
This pull request adds the https://sphinx-autoapi.readthedocs.io/en/latest/ package as a ROS `doc_depend`. It also updates the documentation.