### PR TITLE
refactor(functions): rename 'functions' module to 'helpers'

### DIFF
--- a/panda_gazebo/src/panda_gazebo/common/helpers.py
+++ b/panda_gazebo/src/panda_gazebo/common/helpers.py
@@ -1,4 +1,4 @@
-"""Module containing some additional functions used in the
+"""Module containing some additional helper functions used in the
 :panda-gazebo:`panda_gazebo <>` package.
 """
 import copy

--- a/panda_gazebo/src/panda_gazebo/core/control_server.py
+++ b/panda_gazebo/src/panda_gazebo/core/control_server.py
@@ -41,7 +41,7 @@ from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64
 
 from panda_gazebo.common import ControlledJointsDict
-from panda_gazebo.common.functions import (
+from panda_gazebo.src.panda_gazebo.common.helpers import (
     action_server_exists,
     controller_list_array_2_dict,
     get_duplicate_list,

--- a/panda_gazebo/src/panda_gazebo/core/control_switcher.py
+++ b/panda_gazebo/src/panda_gazebo/core/control_switcher.py
@@ -23,7 +23,11 @@ from controller_manager_msgs.srv import (
 from rospy.exceptions import ROSException, ROSInterruptException
 
 from panda_gazebo.common import ControllerInfoDict
-from panda_gazebo.common.functions import dict_clean, flatten_list, get_unique_list
+from panda_gazebo.src.panda_gazebo.common.helpers import (
+    dict_clean,
+    flatten_list,
+    get_unique_list,
+)
 
 # Global script vars.
 ARM_CONTROLLERS = {

--- a/panda_gazebo/src/panda_gazebo/core/moveit_server.py
+++ b/panda_gazebo/src/panda_gazebo/core/moveit_server.py
@@ -44,7 +44,7 @@ from sensor_msgs.msg import JointState
 from std_msgs.msg import Header
 
 from panda_gazebo.cfg import MoveitServerConfig
-from panda_gazebo.common.functions import (
+from panda_gazebo.src.panda_gazebo.common.helpers import (
     flatten_list,
     get_duplicate_list,
     get_unique_list,


### PR DESCRIPTION
This commit renames the 'functions' module to 'helpers' since this is more in line with my other
packages and less generic.
